### PR TITLE
ISSUE-33 made transmission unit tests more unity

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -73,41 +73,14 @@ module.exports = function(client) {
         json: mappedInput
       };
 
-      client.post(options, callback /*function (err, res, body) {
-        if (err) {
-          callback(err);
-        } else if (typeof res === 'undefined' || typeof res.body === 'undefined') {
-          /*
-           * If we're in here then something very strange has happened because we didn't
-           * get a properly formatted response from the API call, so give generic error
-           * since that's the best we can do in this case
-           *
-           * Note that this is the case for both successful responses and error responses
-           */
-          /*callback(new Error('Unexpected error occurred while trying to send transmission'));
-        } else if (res.statusCode !== 200) {
-          callback(res.body.errors);
-        } else {
-          callback(null, body);
-        }
-      }*/);
+      client.post(options, callback);
     },
     all: function (callback) {
       var options = {
         uri: api
       };
 
-      client.get(options, callback /*function(err, res, body) {
-        if (err) {
-          callback(new Error('Unable to contact Transmissions API: ' + err));
-        } else if (res.statusCode === 404) {
-          callback(new Error('The specified Transmission ID does not exist'));
-        } else if (res.statusCode !== 200) {
-          callback(new Error('Received bad response from Transmission API: ' + res.statusCode));
-        } else {
-          callback(null, body);
-        }
-      }*/);
+      client.get(options, callback);
     },
     find: function (transmissionID, callback) {
       var options = {
@@ -124,17 +97,7 @@ module.exports = function(client) {
         return;
       }
 
-      client.get(options, callback /*function(err, res, body) {
-        if (err) {
-          callback(new Error('Unable to contact Transmissions API: ' + err));
-        } else if (res.statusCode === 404) {
-          callback(new Error('The specified Transmission ID does not exist'));
-        } else if (res.statusCode !== 200) {
-          callback(new Error('Received bad response from Transmission API: ' + res.statusCode));
-        } else {
-          callback(null, body);
-        }
-      }*/);
+      client.get(options, callback);
     }
   };
 

--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -55,6 +55,17 @@ module.exports = function(client) {
 
   return {
     send: function (transmissionBody, callback) {
+
+      if(typeof transmissionBody === 'function') {
+        callback = transmissionBody;
+        transmissionBody = null;
+      }
+
+      if(!transmissionBody) {
+        callback(new Error('transmissionBody is required'));
+        return;
+      }
+
       var mappedInput = toApiFormat(transmissionBody);
 
       var options = {
@@ -102,6 +113,16 @@ module.exports = function(client) {
       var options = {
         uri: api + '/' + transmissionID
       };
+
+      if(typeof transmissionID === 'function') {
+        callback = transmissionID;
+        transmissionID = null;
+      }
+
+      if(!transmissionID) {
+        callback(new Error('transmissionID is required'));
+        return;
+      }
 
       client.get(options, callback /*function(err, res, body) {
         if (err) {

--- a/test/spec/transmissions.spec.js
+++ b/test/spec/transmissions.spec.js
@@ -1,9 +1,7 @@
 var chai = require('chai')
   , expect = chai.expect
   , sinon = require('sinon')
-  , sinonChai = require('sinon-chai')
-  , nock = require('nock')
-  , SparkPost = require('../../lib/index');
+  , sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 


### PR DESCRIPTION
I cleaned up the transmissions unit tests so that they are more truly unit tests. I removed some dead code and reorganized a little. I also added some error checking in the transmissions library. This closes #33.