### PR TITLE
Fix doc about using process.env.SPARKPOST_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var client = new SparkPost('YOUR_API_KEY');
 
 Using an API key stored in an environment variable
 ```js
-process.env.SPARKPOST_API_KEY = 'YOUR_API_KEY';
+#Create an env var as SPARKPOST_API_KEY
 var SparkPost = require('sparkpost');
 var client = new SparkPost();
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var client = new SparkPost('YOUR_API_KEY');
 
 Using an API key stored in an environment variable
 ```js
-#Create an env var as SPARKPOST_API_KEY
+//Create an env var as SPARKPOST_API_KEY
 var SparkPost = require('sparkpost');
 var client = new SparkPost();
 ```


### PR DESCRIPTION
The point of using env vars is to hide the API key from the actual code.  However the doc implies you have to set the env var in your code like 

```js
process.env.SPARKPOST_API_KEY='your key';
```

However you should not do that and instead set the env var in something like ~/.profile or ~/.bash_profile