### PR TITLE
Added keywords for searching in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "grunt"
   },
+  "keywords": [
+    "email",
+    "messaging"
+    ],
   "repository": {
     "type": "git",
     "url": "https://github.com/SparkPost/node-sparkpost"


### PR DESCRIPTION
You currently can't find the SparkPost lib by searching for anything but sparkpost.  I does not come up if you search of email.  This should help give the package and our service more visibility.