### PR TITLE
Resolve issue #82

### DIFF
--- a/lib/toApiFormat.js
+++ b/lib/toApiFormat.js
@@ -5,7 +5,7 @@ module.exports = function toApiFormat(source) {
 
   var dest = {};
   // List of property names which we do not want to modify the sub-property names
-  var excludeList = ['recipients', 'substitution_data', 'tags', 'metadata', 'content', 'attributes', 'headers'];
+  var excludeList = ['substitution_data', 'tags', 'metadata', 'attributes', 'headers'];
 
   try{
     // Handle arrays


### PR DESCRIPTION
Make sure to support sending with a stored recipient list or template, while also leaving headers and substitution data alone.