### PR TITLE
removes from and subject from transmission stored template send example

### DIFF
--- a/examples/transmissions/stored_template_send.js
+++ b/examples/transmissions/stored_template_send.js
@@ -6,10 +6,12 @@ var key = 'YOURAPIKEY'
 
 var reqOpts = {
   transmissionBody: {
-    recipients: [{ address: { email: 'john.doe@example.com' } }],
+    campaignId: 'ricks-campaign',
     content: {
-      template_id: 'my-template'
-    }
+      template_id: 'ricks-template'
+    },
+    'num_rcpt_errors': 3,
+    recipients: [{ address: { email: 'rick.sanchez@rickandmorty100years.com', name: 'Rick Sanchez' } }]
   }
 };
 
@@ -18,6 +20,6 @@ client.transmissions.send(reqOpts, function(err, res) {
     console.log(err);
   } else {
     console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log('What up my glib globs! SparkPost!');
   }
 });

--- a/examples/transmissions/stored_template_send.js
+++ b/examples/transmissions/stored_template_send.js
@@ -8,9 +8,7 @@ var reqOpts = {
   transmissionBody: {
     recipients: [{ address: { email: 'john.doe@example.com' } }],
     content: {
-      template_id: 'my-template',
-      from: 'From Envelope <example@sparkpostbox.com>',
-      subject: 'Example Email for Stored Template'
+      template_id: 'my-template'
     }
   }
 };


### PR DESCRIPTION
I cleaned up our existing template send example. Unless you are doing something fancy with substitution data, people won't be submitting from and subject in the template send.

closes #99 