### PR TITLE
Returns body.results or body as a response. Added debug support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install sparkpost
       * standard `callback(err, data)`
       * `err` - any error that occurred
       * `data` - results from API call
-      * `data.debug` - full response from request client
+      * `data.debug` - full response from request client when `options.debug` is `true`
 * **get | post | put | delete(options, callback)**
     * `options` - see request options
     * `callback` - see request options

--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ npm install sparkpost
 * **request(options, callback)**
     * `options` - [see request modules options](https://github.com/mikeal/request#requestoptions-callback)
     * `options.uri` - can either be a full url or a path that is appended to `options.origin` used at initialization ([url.resolve](http://nodejs.org/api/url.html#url_url_resolve_from_to))
+    * `options.debug` - setting to `true` includes full response from request client for debugging purposes
     * `callback` - executed after task is completed. **required**
       * standard `callback(err, data)`
       * `err` - any error that occurred
-      * `data.res` - full response from request client
-      * `data.body` - payload from response
+      * `data` - results from API call
+      * `data.debug` - full response from request client
 * **get | post | put | delete(options, callback)**
     * `options` - see request options
     * `callback` - see request options
@@ -97,7 +98,7 @@ client.get(options, function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 ```
 

--- a/docs/resources/inboundDomains.md
+++ b/docs/resources/inboundDomains.md
@@ -34,7 +34,7 @@ client.inboundDomains.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/messageEvents.md
+++ b/docs/resources/messageEvents.md
@@ -6,8 +6,8 @@ This library provides easy access to the [Message Events](https://www.sparkpost.
 * **search(params, callback)**
   Search for message events using the given parameters (NOTE: all params are optional):
   * `params.bounce_classes` - list of [bounce classes](https://support.sparkpost.com/customer/portal/articles/1929896)
-  * `params.campaign_ids` - campaign IDs 
-  * `params.events` - event types 
+  * `params.campaign_ids` - campaign IDs
+  * `params.events` - event types
   * `params.friendly_froms` - 'friendly' from addressess
   * `params.from` - time lower bound  (see below for date/time format details)
   * `params.message_ids` - message IDs
@@ -52,7 +52,7 @@ client.messageEvents.search(searchParams, function(err, res) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/recipientLists.md
+++ b/docs/resources/recipientLists.md
@@ -42,7 +42,7 @@ client.recipientLists.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/relayWebhooks.md
+++ b/docs/resources/relayWebhooks.md
@@ -47,7 +47,7 @@ client.relayWebhooks.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/sendingDomains.md
+++ b/docs/resources/sendingDomains.md
@@ -39,7 +39,7 @@ client.sendingDomains.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/subaccounts.md
+++ b/docs/resources/subaccounts.md
@@ -41,6 +41,6 @@ client.subaccounts.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 ```

--- a/docs/resources/suppressionList.md
+++ b/docs/resources/suppressionList.md
@@ -37,7 +37,7 @@ client.suppressionList.search(parameters, function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/templates.md
+++ b/docs/resources/templates.md
@@ -41,7 +41,7 @@ client.templates.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/docs/resources/webhooks.md
+++ b/docs/resources/webhooks.md
@@ -57,7 +57,7 @@ client.webhooks.all(function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });
 
 ```

--- a/examples/baseObject/getDomainsList.js
+++ b/examples/baseObject/getDomainsList.js
@@ -13,5 +13,5 @@ client.get(options, function(err, data) {
     return;
   }
 
-  console.log(data.body);
+  console.log(data);
 });

--- a/examples/inboundDomains/create_inboundDomain.js
+++ b/examples/inboundDomains/create_inboundDomain.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.inboundDomains.create('example1.com', function(err, res) {
+client.inboundDomains.create('example1.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/inboundDomains/delete_inboundDomain.js
+++ b/examples/inboundDomains/delete_inboundDomain.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.inboundDomains.delete('example1.com', function(err, res) {
+client.inboundDomains.delete('example1.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/inboundDomains/find_inboundDomain.js
+++ b/examples/inboundDomains/find_inboundDomain.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.inboundDomains.find('example1.com', function(err, res) {
+client.inboundDomains.find('example1.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/inboundDomains/get_all_inboundDomains.js
+++ b/examples/inboundDomains/get_all_inboundDomains.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.inboundDomains.all(function(err, res) {
+client.inboundDomains.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/messageEvents/all_messageEvents.js
+++ b/examples/messageEvents/all_messageEvents.js
@@ -4,12 +4,12 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.messageEvents.search({}, function(err, res) {
+client.messageEvents.search({}, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });
 

--- a/examples/messageEvents/search_campaignClicks.js
+++ b/examples/messageEvents/search_campaignClicks.js
@@ -8,12 +8,12 @@ var key = 'YOURAPIKEY'
       campaign_ids: 'monday_mailshot'
     };
 
-client.messageEvents.search(searchParams, function(err, res) {
+client.messageEvents.search(searchParams, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });
 

--- a/examples/messageEvents/search_messageEvents.js
+++ b/examples/messageEvents/search_messageEvents.js
@@ -12,12 +12,12 @@ var key = 'YOURAPIKEY'
       bounce_classes: [10]
     };
 
-client.messageEvents.search(searchParams, function(err, res) {
+client.messageEvents.search(searchParams, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });
 

--- a/examples/recipientLists/create_recipientList.js
+++ b/examples/recipientLists/create_recipientList.js
@@ -25,11 +25,11 @@ var key = 'YOURAPIKEY'
     ]
   };
 
-client.recipientLists.create(options, function(err, res) {
+client.recipientLists.create(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/recipientLists/delete_recipientList.js
+++ b/examples/recipientLists/delete_recipientList.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.recipientLists['delete']('UNIQUE_TEST_ID', function(err, res) {
+client.recipientLists['delete']('UNIQUE_TEST_ID', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/recipientLists/get_all_recipientLists.js
+++ b/examples/recipientLists/get_all_recipientLists.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.recipientLists.all(function(err, res) {
+client.recipientLists.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/recipientLists/get_recipientList.js
+++ b/examples/recipientLists/get_recipientList.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     id: 'UNIQUE_TEST_ID'
   };
 
-client.recipientLists.find(options, function(err, res) {
+client.recipientLists.find(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/recipientLists/get_recipientList_with_recipients.js
+++ b/examples/recipientLists/get_recipientList_with_recipients.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , show_recipients: true
   };
 
-client.recipientLists.find(options, function(err, res) {
+client.recipientLists.find(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/recipientLists/update_recipientList.js
+++ b/examples/recipientLists/update_recipientList.js
@@ -25,11 +25,11 @@ var key = 'YOURAPIKEY'
     ]
   };
 
-client.recipientLists.update(options, function(err, res) {
+client.recipientLists.update(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/relayWebhooks/create_relayWebhook.js
+++ b/examples/relayWebhooks/create_relayWebhook.js
@@ -9,11 +9,11 @@ var key = 'YOURAPIKEY'
     , domain: 'inbound.example.com'
   };
 
-client.relayWebhooks.create(options, function(err, res) {
+client.relayWebhooks.create(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/relayWebhooks/delete_relayWebhook.js
+++ b/examples/relayWebhooks/delete_relayWebhook.js
@@ -5,11 +5,11 @@ var key = 'YOURAPIKEY'
   , client = new SparkPost(key)
   , relayWebhookId = '123456789';
 
-client.relayWebhooks.delete(relayWebhookId, function(err, res) {
+client.relayWebhooks.delete(relayWebhookId, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/relayWebhooks/find_relayWebhook.js
+++ b/examples/relayWebhooks/find_relayWebhook.js
@@ -5,11 +5,11 @@ var key = 'YOURAPIKEY'
   , client = new SparkPost(key)
   , relayWebhookId = '123456789';
 
-client.relayWebhooks.find(relayWebhookId, function(err, res) {
+client.relayWebhooks.find(relayWebhookId, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/relayWebhooks/get_all_relayWebhooks.js
+++ b/examples/relayWebhooks/get_all_relayWebhooks.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.relayWebhooks.all(function(err, res) {
+client.relayWebhooks.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/relayWebhooks/update_relayWebhook.js
+++ b/examples/relayWebhooks/update_relayWebhook.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , target: 'http://client.test.com/test-webhook'
   };
 
-client.relayWebhooks.update(options, function(err, res) {
+client.relayWebhooks.update(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/create_sendingDomain.js
+++ b/examples/sendingDomains/create_sendingDomain.js
@@ -14,11 +14,11 @@ var domain = {
   }
 };
 
-client.sendingDomains.create(domain, function(err, res) {
+client.sendingDomains.create(domain, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/get_all_sendingDomains.js
+++ b/examples/sendingDomains/get_all_sendingDomains.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.sendingDomains.all(function(err, res) {
+client.sendingDomains.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/get_sendingDomain.js
+++ b/examples/sendingDomains/get_sendingDomain.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.sendingDomains.find('example1.com', function(err, res) {
+client.sendingDomains.find('example1.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/update_sendingDomain.js
+++ b/examples/sendingDomains/update_sendingDomain.js
@@ -14,11 +14,11 @@ var key = 'YOURAPIKEY'
     }
   };
 
-client.sendingDomains.update(domain, function(err, res) {
+client.sendingDomains.update(domain, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/verify_sendingDomain_default.js
+++ b/examples/sendingDomains/verify_sendingDomain_default.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     domain: 'example1.com'
   };
 
-client.sendingDomains.verify(options, function(err, res) {
+client.sendingDomains.verify(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/verify_sendingDomain_dkim_only.js
+++ b/examples/sendingDomains/verify_sendingDomain_dkim_only.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , verifySPF: false
   };
 
-client.sendingDomains.verify(options, function(err, res) {
+client.sendingDomains.verify(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/sendingDomains/verify_sendingDomain_spf_only.js
+++ b/examples/sendingDomains/verify_sendingDomain_spf_only.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , verifyDKIM: false
   };
 
-client.sendingDomains.verify(options, function(err, res) {
+client.sendingDomains.verify(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/suppressionList/checkStatus.js
+++ b/examples/suppressionList/checkStatus.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.suppressionList.checkStatus('test@test.com', function(err, res) {
+client.suppressionList.checkStatus('test@test.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/suppressionList/removeStatus.js
+++ b/examples/suppressionList/removeStatus.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.suppressionList.removeStatus('test@test.com', function(err, res) {
+client.suppressionList.removeStatus('test@test.com', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/suppressionList/search_suppressionList.js
+++ b/examples/suppressionList/search_suppressionList.js
@@ -9,11 +9,11 @@ var key = 'YOURAPIKEY'
     , limit: 5
   };
 
-client.suppressionList.search(parameters, function(err, res) {
+client.suppressionList.search(parameters, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/suppressionList/upsert.js
+++ b/examples/suppressionList/upsert.js
@@ -10,11 +10,11 @@ var key = 'YOURAPIKEY'
     , description: 'Test description'
   };
 
-client.suppressionList.upsert(recipient, function(err, res) {
+client.suppressionList.upsert(recipient, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/suppressionList/upsert_bulk.js
+++ b/examples/suppressionList/upsert_bulk.js
@@ -24,11 +24,11 @@ var key = 'YOURAPIKEY'
     }
   ];
 
-client.suppressionList.upsert(recipients, function(err, res) {
+client.suppressionList.upsert(recipients, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/create_template.js
+++ b/examples/templates/create_template.js
@@ -15,11 +15,11 @@ var key = 'YOURAPIKEY'
     }
   };
 
-client.templates.create(options, function(err, res) {
+client.templates.create(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/delete_template.js
+++ b/examples/templates/delete_template.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.templates['delete']('TEST_ID', function(err, res) {
+client.templates['delete']('TEST_ID', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/get_all_templates.js
+++ b/examples/templates/get_all_templates.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.templates.all(function(err, res) {
+client.templates.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/get_draft_template.js
+++ b/examples/templates/get_draft_template.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , draft: true
   };
 
-client.templates.find(options, function(err, res) {
+client.templates.find(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/get_template.js
+++ b/examples/templates/get_template.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     id: 'TEST_ID'
   };
 
-client.templates.find(options, function(err, res) {
+client.templates.find(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/preview_template.js
+++ b/examples/templates/preview_template.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , data: {}
   };
 
-client.templates.preview(options, function(err, res) {
+client.templates.preview(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/update_published_template.js
+++ b/examples/templates/update_published_template.js
@@ -15,11 +15,11 @@ var key = 'YOURAPIKEY'
     , update_published: true
   };
 
-client.templates.update(options, function(err, res) {
+client.templates.update(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/templates/update_template.js
+++ b/examples/templates/update_template.js
@@ -14,11 +14,11 @@ var key = 'YOURAPIKEY'
     }
   };
 
-client.templates.update(options, function(err, res) {
+client.templates.update(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/get_all_transmissions.js
+++ b/examples/transmissions/get_all_transmissions.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.transmissions.all(function(err, res) {
+client.transmissions.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/get_transmission.js
+++ b/examples/transmissions/get_transmission.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.transmissions.find('YOUR-TRANSMISSION-KEY', function(err, res) {
+client.transmissions.find('YOUR-TRANSMISSION-KEY', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/get_transmissions_by_campaign.js
+++ b/examples/transmissions/get_transmissions_by_campaign.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     campaign_id: 'my_campaign'
   };
 
-client.transmissions.all(options, function(err, res) {
+client.transmissions.all(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/get_transmissions_by_template.js
+++ b/examples/transmissions/get_transmissions_by_template.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     template_id: 'my_template'
   };
 
-client.transmissions.all(options, function(err, res) {
+client.transmissions.all(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/mime_parts.js
+++ b/examples/transmissions/mime_parts.js
@@ -20,11 +20,11 @@ var reqObj = {
   }
 };
 
-client.transmissions.send(reqObj, function(err, res) {
+client.transmissions.send(reqObj, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/rfc822.js
+++ b/examples/transmissions/rfc822.js
@@ -13,11 +13,11 @@ var reqObj = {
   }
 };
 
-client.transmissions.send(reqObj, function(err, res) {
+client.transmissions.send(reqObj, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/send_transmission_all_fields.js
+++ b/examples/transmissions/send_transmission_all_fields.js
@@ -55,11 +55,11 @@ var reqOpts = {
   }
 };
 
-client.transmissions.send(reqOpts, function(err, res) {
+client.transmissions.send(reqOpts, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log("Congrats you can use our SDK!");
+    console.log(data);
+    console.log("Congrats you can use our client library!");
   }
 });

--- a/examples/transmissions/stored_recipients_inline_content.js
+++ b/examples/transmissions/stored_recipients_inline_content.js
@@ -18,11 +18,11 @@ var reqObj = {
   }
 };
 
-client.transmissions.send(reqObj, function(err, res) {
+client.transmissions.send(reqObj, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/stored_recipients_stored_content.js
+++ b/examples/transmissions/stored_recipients_stored_content.js
@@ -17,11 +17,11 @@ var reqOpts = {
   }
 };
 
-client.transmissions.send(reqOpts, function(err, res) {
+client.transmissions.send(reqOpts, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/transmissions/stored_template_send.js
+++ b/examples/transmissions/stored_template_send.js
@@ -15,11 +15,11 @@ var reqOpts = {
   }
 };
 
-client.transmissions.send(reqOpts, function(err, res) {
+client.transmissions.send(reqOpts, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
+    console.log(data);
     console.log('What up my glib globs! SparkPost!');
   }
 });

--- a/examples/webhooks/create_webhook.js
+++ b/examples/webhooks/create_webhook.js
@@ -15,11 +15,11 @@ var key = 'YOURAPIKEY'
     ]
   };
 
-client.webhooks.create(webhook, function(err, res) {
+client.webhooks.create(webhook, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/delete_webhook.js
+++ b/examples/webhooks/delete_webhook.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.webhooks['delete']('TEST_WEBHOOK_UUID', function(err, res) {
+client.webhooks['delete']('TEST_WEBHOOK_UUID', function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/describe_webhook.js
+++ b/examples/webhooks/describe_webhook.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , timezone: 'America/New_York'
   };
 
-client.webhooks.describe(options, function(err, res) {
+client.webhooks.describe(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/getBatchStatus.js
+++ b/examples/webhooks/getBatchStatus.js
@@ -8,11 +8,11 @@ var key = 'YOURAPIKEY'
     , limit: 1000
   };
 
-client.webhooks.getBatchStatus(options, function(err, res) {
+client.webhooks.getBatchStatus(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/getDocumentation.js
+++ b/examples/webhooks/getDocumentation.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.webhooks.getDocumentation(function(err, res) {
+client.webhooks.getDocumentation(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/getSamples.js
+++ b/examples/webhooks/getSamples.js
@@ -7,11 +7,11 @@ var key = 'YOURAPIKEY'
     events: 'bounce'
   };
 
-client.webhooks.getSamples(options, function(err, res) {
+client.webhooks.getSamples(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/get_all_webhooks.js
+++ b/examples/webhooks/get_all_webhooks.js
@@ -4,11 +4,11 @@ var key = 'YOURAPIKEY'
   , SparkPost = require('sparkpost')
   , client = new SparkPost(key);
 
-client.webhooks.all(function(err, res) {
+client.webhooks.all(function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/update_webhook.js
+++ b/examples/webhooks/update_webhook.js
@@ -12,11 +12,11 @@ var key = 'YOURAPIKEY'
     ]
   };
 
-client.webhooks.update(webhook, function(err, res) {
+client.webhooks.update(webhook, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/examples/webhooks/validate_webhook.js
+++ b/examples/webhooks/validate_webhook.js
@@ -10,11 +10,11 @@ var key = 'YOURAPIKEY'
     }
   };
 
-client.webhooks.validate(options, function(err, res) {
+client.webhooks.validate(options, function(err, data) {
   if (err) {
     console.log(err);
   } else {
-    console.log(res.body);
-    console.log('Congrats you can use our SDK!');
+    console.log(data);
+    console.log('Congrats you can use our client library!');
   }
 });

--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -32,6 +32,16 @@ var handleOptions = function(apiKey, options) {
   return options;
 };
 
+var createSparkPostError = function(res, body) {
+  body = body || {};
+  var err = new Error(res.statusMessage);
+  err.name = 'SparkPostError';
+  err.errors = body.errors;
+  err.statusCode = res.statusCode;
+
+  return err;
+};
+
 var SparkPost = function(apiKey, options) {
 
   options = handleOptions(apiKey, options);
@@ -101,11 +111,7 @@ SparkPost.prototype.request = function( options, callback ) {
     if(err) {
       return callback(err, res);
     } else if(invalidCodeRegex.test(res.statusCode)) {
-      body = body || {};
-      err = new Error(res.statusMessage);
-      err.name = 'SparkPostError';
-      err.errors = body.errors;
-      err.statusCode = res.statusCode;
+      err = createSparkPostError(res, body);
       return callback(err, res);
     } else {
       var response = body.results || body;

--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -85,6 +85,9 @@ SparkPost.prototype.request = function( options, callback ) {
   // set Strict SSL (Always true)
   options.strictSSL = true;
 
+  // set JSON (Always true)
+  options.json = true;
+
   // default to accepting gzipped responses
   if (typeof options.gzip === 'undefined') {
     options.gzip = true;
@@ -101,7 +104,11 @@ SparkPost.prototype.request = function( options, callback ) {
       err.statusCode = res.statusCode;
       return callback(err, res);
     } else {
-      return callback(null, res);
+      var response = body.results || body;
+      if(options.debug) {
+        response.debug = res;
+      }
+      return callback(null, response);
     }
   });
 };

--- a/test/spec/SendGridCompatibility/index.spec.js
+++ b/test/spec/SendGridCompatibility/index.spec.js
@@ -128,7 +128,7 @@ describe('SendGrid Compatibility', function() {
 
     it('should respond when the test succeeds', function(done) {
       sendgrid.send({}, function(err, res) {
-        expect(res.body.ok).to.be.true;
+        expect(res.ok).to.be.true;
         expect(err).to.equal(null);
         done();
       });

--- a/test/spec/sparkpost.spec.js
+++ b/test/spec/sparkpost.spec.js
@@ -94,11 +94,12 @@ describe('SparkPost Library', function() {
       var options = {
         method: 'GET'
         , uri: 'get/test'
+        , debug: true
       };
 
       client.request(options, function(err, data) {
         // making sure original request was GET
-        expect(data.request.method).to.equal('GET');
+        expect(data.debug.request.method).to.equal('GET');
 
         // finish async test
         done();
@@ -157,10 +158,11 @@ describe('SparkPost Library', function() {
       var options = {
         method: 'GET'
         , uri: 'https://test.sparkpost.com/test'
+        , debug: true
       };
 
       client.request(options, function(err, data) {
-        expect(data.request.uri.href).to.equal('https://test.sparkpost.com/test');
+        expect(data.debug.request.uri.href).to.equal('https://test.sparkpost.com/test');
 
         // finish async test
         done();
@@ -174,9 +176,10 @@ describe('SparkPost Library', function() {
         , options = {
           method: 'GET'
           , uri: 'https://test.sparkpost.com/test'
-          };
+          , debug: true
+        };
 
-      zlib.gzip(TEST_MESSAGE+TEST_MESSAGE, function(err, gzipped) {
+      zlib.gzip(JSON.stringify({ msg: TEST_MESSAGE+TEST_MESSAGE }), function(err, gzipped) {
         expect(err).to.be.null;
         compressedMsg = gzipped;
         gzipNock = nock('https://test.sparkpost.com', {
@@ -192,9 +195,9 @@ describe('SparkPost Library', function() {
           });
         client.request(options, function(err, data) {
           expect(err).to.be.null;
-          expect(data.statusCode).to.equal(200);
-          expect(data.body).to.equal(TEST_MESSAGE + TEST_MESSAGE);
- 
+          expect(data.debug.statusCode).to.equal(200);
+          expect(data.msg).to.equal(TEST_MESSAGE + TEST_MESSAGE);
+
           // finish async test
           done();
         });
@@ -206,19 +209,20 @@ describe('SparkPost Library', function() {
 
       nock('https://test.sparkpost.com')
         .get('/test')
-        .reply(200, TEST_MESSAGE);
+        .reply(200, { msg: TEST_MESSAGE });
 
       var options = {
         method: 'GET'
         , uri: 'https://test.sparkpost.com/test'
         , gzip: false
+        , debug: true
       };
 
       client.request(options, function(err, data) {
         expect(err).to.be.null;
-        expect(data.statusCode).to.equal(200);
-        expect(data.body).to.equal(TEST_MESSAGE);
-        expect(data.headers).not.to.have.property('content-encoding');
+        expect(data.debug.statusCode).to.equal(200);
+        expect(data.msg).to.equal(TEST_MESSAGE);
+        expect(data.debug.headers).not.to.have.property('content-encoding');
 
         // finish async test
         done();
@@ -237,12 +241,12 @@ describe('SparkPost Library', function() {
         .get('/api/v1/get/test')
         .reply(200, { ok: true });
 
-      client.get({uri: 'get/test'}, function(err, data) {
+      client.get({uri: 'get/test', debug: true}, function(err, data) {
         // need to make sure we called request method
         expect(requestSpy.calledOnce).to.be.true;
 
         // making sure original request was GET
-        expect(data.request.method).to.equal('GET');
+        expect(data.debug.request.method).to.equal('GET');
 
         SparkPost.prototype.request.restore(); // restoring function
         done();
@@ -266,6 +270,7 @@ describe('SparkPost Library', function() {
         , json: {
           testingData: 'test data'
         }
+        , debug: true
       };
 
       client.post(reqOptions, function(err, data) {
@@ -273,7 +278,7 @@ describe('SparkPost Library', function() {
         expect(requestSpy.calledOnce).to.be.true;
 
         // making sure original request was POST
-        expect(data.request.method).to.equal('POST');
+        expect(data.debug.request.method).to.equal('POST');
 
         SparkPost.prototype.request.restore(); // restoring function
         done();
@@ -297,6 +302,7 @@ describe('SparkPost Library', function() {
         , json: {
           testingData: 'test data'
         }
+        , debug: true
       };
 
       client.put(reqOptions, function(err, data) {
@@ -304,7 +310,7 @@ describe('SparkPost Library', function() {
         expect(requestSpy.calledOnce).to.be.true;
 
         // making sure original request was PUT
-        expect(data.request.method).to.equal('PUT');
+        expect(data.debug.request.method).to.equal('PUT');
 
         SparkPost.prototype.request.restore(); // restoring function
         done();
@@ -328,6 +334,7 @@ describe('SparkPost Library', function() {
         , json: {
           testingData: 'test data'
         }
+        , debug: true
       };
 
       client.delete(reqOptions, function(err, data) {
@@ -335,7 +342,7 @@ describe('SparkPost Library', function() {
         expect(requestSpy.calledOnce).to.be.true;
 
         // making sure original request was DELETE
-        expect(data.request.method).to.equal('DELETE');
+        expect(data.debug.request.method).to.equal('DELETE');
 
         SparkPost.prototype.request.restore(); // restoring function
         done();


### PR DESCRIPTION
- Set `options.json = true` for all requests. 
- Using JSON parsed `body` from request. 
- Returning `body.results || body` as response
- Added a `options.debug` flag which will include the request `response` object as a `debug` property on response. (aids in testing)

Closes #81