### PR TITLE
Let inboundDomains.create() use a domain name as per the docs

### DIFF
--- a/lib/inboundDomains.js
+++ b/lib/inboundDomains.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var api = 'inbound-domains'
-  , toApiFormat = require('./toApiFormat');
+var api = 'inbound-domains';
 
 module.exports = function(client) {
   var inboundDomains = {
@@ -41,7 +40,7 @@ module.exports = function(client) {
       var options = {
         uri: api
         , json: {
-          domain: toApiFormat(domain)
+          domain: domain
         }
       };
       client.post(options, callback);

--- a/lib/inboundDomains.js
+++ b/lib/inboundDomains.js
@@ -40,7 +40,9 @@ module.exports = function(client) {
 
       var options = {
         uri: api
-        , json: toApiFormat(domain)
+        , json: {
+          domain: toApiFormat(domain)
+        }
       };
       client.post(options, callback);
     },


### PR DESCRIPTION
The `json` object needs to contain an object like `{ domain: myDomain }` rather than a plain string domain name.