### PR TITLE
Upgrade lodash version to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "json-pointer": "^0.5.0",
-    "lodash": "^3.9.3",
+    "lodash": "^4.13.1",
     "request": "^2.72.0"
   }
 }


### PR DESCRIPTION
lodash v3 has an issue that causes TypeError: Cannot read property 'prototype' of undefined.
This has been fixed in v4 (lodash/lodash#223).