### PR TITLE
Add more useful details to the User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ npm install sparkpost
     * Required: no
     * Type: `String`
     * Default: `v1`
+* `options.stackIdentity`
+    * Required: no
+    * Type: `String`
+    * An optional identifier to include in the User-Agent header. e.g. `product/1.0.0`
 * `options.headers`
     * Required: no
     * Type: `Object`

--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -5,7 +5,7 @@ var version = require('../package.json').version
   , Promise = require('./Promise')
   , request = require('request')
   , _ = require('lodash')
-  , defaults, resolveUri, handleOptions, createSparkPostError, SparkPost;
+  , defaults, resolveUri, handleOptions, createSparkPostError, createVersionStr, SparkPost;
 
 //REST API Config Defaults
 defaults = {
@@ -45,6 +45,14 @@ createSparkPostError = function(res, body) {
   return err;
 };
 
+createVersionStr = function(version, options) {
+  let versionStr = 'node-sparkpost/' + version + ' node.js/' + process.version;
+  if (options.stackIdentity) {
+    versionStr += options.stackIdentity + ' ' + versionStr;
+  }
+  return versionStr;
+};
+
 SparkPost = function(apiKey, options) {
 
   options = handleOptions(apiKey, options);
@@ -60,7 +68,7 @@ SparkPost = function(apiKey, options) {
 
   // setting up default headers
   this.defaultHeaders = _.merge({
-    'User-Agent': 'node-sparkpost/' + this.version
+    'User-Agent': createVersionStr(version, options)
     , 'Content-Type': 'application/json'
   }, options.headers);
 


### PR DESCRIPTION
Adds a Node.js version string and an optional "stack identifier" so we can track libs that use node-sparkpost such as nodemailer-sparkpost-transport.
