### PR TITLE
Issue-213: Optional automatic retry on 5xx

### DIFF
--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -11,6 +11,7 @@ const defaults = {
   origin: 'https://api.sparkpost.com:443',
   apiVersion: 'v1',
   debug: false
+  /*retries: undefined*/
 };
 
 const resolveUri = function(origin, uri) {
@@ -72,9 +73,7 @@ const SparkPost = function(apiKey, options) {
   }, options.headers);
 
   //Optional client config
-  this.origin = options.origin;
-  this.apiVersion = options.apiVersion || defaults.apiVersion;
-  this.debug = (typeof options.debug === 'boolean') ? options.debug : defaults.debug;
+  this.optionalConfig(options);
 
   this.inboundDomains = require('./inboundDomains')(this);
   this.messageEvents = require('./messageEvents')(this);
@@ -86,6 +85,13 @@ const SparkPost = function(apiKey, options) {
   this.templates = require('./templates')(this);
   this.transmissions = require('./transmissions')(this);
   this.webhooks = require('./webhooks')(this);
+};
+
+SparkPost.prototype.optionalConfig = function(options) {
+  this.origin = options.origin;
+  this.apiVersion = options.apiVersion || defaults.apiVersion;
+  this.debug = (typeof options.debug === 'boolean') ? options.debug : defaults.debug;
+  this.retries = (typeof options.retries === 'number') ? options.retries : defaults.retries;
 };
 
 SparkPost.prototype.request = function(options, callback) {
@@ -116,8 +122,15 @@ SparkPost.prototype.request = function(options, callback) {
   // set debug
   options.debug = (typeof options.debug === 'boolean') ? options.debug : this.debug;
 
+  // Use a request handler which supports retries
+  let requestFn = request;
+  if (this.retries) {
+    requestFn = requestWithRetry;
+    options.retries = this.retries;
+  }
+
   return withCallback(new Promise(function(resolve, reject) {
-    request(options, function(err, res, body) {
+    requestFn(options, function(err, res, body) {
       const invalidCodeRegex = /(5|4)[0-9]{2}/;
       let response;
 
@@ -136,6 +149,18 @@ SparkPost.prototype.request = function(options, callback) {
     });
   }), callback);
 };
+
+function requestWithRetry(options, cb) {
+  request(options, function(err, res, body) {
+    if (!err && res.statusCode >= 500 && res.statusCode <= 599) {
+      options.retries--;
+      if (options.retries >= 0) {
+        return requestWithRetry(options, cb);
+      }
+    }
+    return cb(err, res, body);
+  });
+}
 
 SparkPost.prototype.get = function(options, callback) {
   options.method = 'GET';


### PR DESCRIPTION
Addresses #213:
 - Constructor now accepts a numeric `retries` option which defaults to `undefined`.
 - By default, no retries are attempted.
 - Each request will be retried until it returns a non 5xx status or until `retries` attempts are reached.
