### PR TITLE
ISSUE-234: Document how to configure for the EU API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ npm install sparkpost
 * `options.origin` or `options.endpoint`
     * Required: no
     * Type: `String`
-    * Default: `https://api.sparkpost.com:443`
+    * Default: `https://api.sparkpost.com:443`<br/>
+    *Note: To use the SparkPost EU API you will need to set this to `https://api.eu.sparkpost.com:443`.*
 * `options.apiVersion`
     * Required: no
     * Type: `String`
@@ -120,6 +121,9 @@ successful and if not information about the error that occurred. If a callback i
 ```javascript
 const SparkPost = require('sparkpost');
 const client = new SparkPost('<YOUR API KEY>');
+
+// If you have a SparkPost EU account you will need to pass a different `origin` via the options parameter:
+// const euClient = new SparkPost('<YOUR API KEY>', { origin: 'https://api.eu.sparkpost.com:443' });
 
 client.transmissions.send({
     options: {


### PR DESCRIPTION
There does not appear to be any clear documentation to suggest that EU accounts need to configure the client slightly differently in order for it to work.

Without setting the `origin` via the options parameter when initiating a client any requests made with a token from an EU account will return a cryptic 401 error, since requests are going to the US API.

This change adds some explicit mentions of the slightly different configuration needed to get the library working with an EU account.